### PR TITLE
enable weight expression editor

### DIFF
--- a/pipe-gui/src/main/java/pipe/gui/widgets/ArcWeightEditorPanel.java
+++ b/pipe-gui/src/main/java/pipe/gui/widgets/ArcWeightEditorPanel.java
@@ -237,7 +237,6 @@ public class ArcWeightEditorPanel extends javax.swing.JPanel {
         guiDialog.add(feditor);
         guiDialog.setSize(270, 230);
         guiDialog.setVisible(true);
-        guiDialog.dispose();
     }
 
     public void setWeight(String func, String id) {


### PR DESCRIPTION
Remove 'guiDialog.dispose();' so weight expression editor is usable.
