### PR TITLE
Issue 22 -- added IOException to interface (PIPECore) 

### DIFF
--- a/pipe-gui/src/main/java/pipe/controllers/application/PipeApplicationController.java
+++ b/pipe-gui/src/main/java/pipe/controllers/application/PipeApplicationController.java
@@ -18,6 +18,7 @@ import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
 
@@ -187,7 +188,7 @@ public class PipeApplicationController {
 
         try {
             manager.savePetriNet(petriNet, outFile);
-        } catch (JAXBException e) {
+        } catch (JAXBException | IOException e) {
             throw new RuntimeException("Failed to write!", e);
         }
         petriNetController.save();


### PR DESCRIPTION
As part of the fix for issue #22 in PIPECore, refactored PetriNetIOImpl; the simplest approach added IOException to the method signature for writeTo(String path, PetriNet petriNet).  This seems more clear, but if it causes headaches, I could change it to the old signature.  