### PR TITLE
Fix NPE in PipeApplicationView. Use slash as path separator for loading

### DIFF
--- a/pipe-gui/src/main/java/pipe/gui/PIPEConstants.java
+++ b/pipe-gui/src/main/java/pipe/gui/PIPEConstants.java
@@ -9,12 +9,12 @@ public final class PIPEConstants {
     /**
      * Resources directory of images
      */
-    public static final String IMAGE_PATH = File.separator + "images" + File.separator;
+    public static final String IMAGE_PATH = "/images" + File.separator;
 
     /**
      * Path to the directory that the PIPE examples are located in
      */
-    public static final String EXAMPLES_PATH = File.separator + "extras" + File.separator + "examples" + File.separator;
+    public static final String EXAMPLES_PATH = "/extras" + File.separator + "examples" + File.separator;
 
     /**
      * Hidden constructor for utility class


### PR DESCRIPTION
Fixes the NPE at startup under JAVA 8 on my windows machine.