### PR TITLE
Removes xerces from dependencies (Java 8 SAX error)

### DIFF
--- a/pipe-gui/pom.xml
+++ b/pipe-gui/pom.xml
@@ -178,6 +178,12 @@
             <groupId>maven</groupId>
             <artifactId>maven-abbot-plugin</artifactId>
             <version>1.1</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>xerces</groupId>  
+                    <artifactId>xercesImpl</artifactId> 
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Fixes bug #96

XML parsing is already implemented in a few major versions of java
afaik. In java 8 using xerces will create the two error messages as
shown in that bug. Further information:
http://stackoverflow.com/a/35366786/2209007