### PR TITLE
pom.xml: Add JAXB dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,10 +75,15 @@
     </distributionManagement>
 
     <dependencies>
-	    <dependency>
-		    <groupId>javax.xml.bind</groupId>
-		    <artifactId>jaxb-api</artifactId>
-		    <version>2.3.0</version>
-	    </dependency>
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>2.3.2</version>
+        </dependency>
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -74,4 +74,11 @@
         </repository>
     </distributionManagement>
 
+    <dependencies>
+	    <dependency>
+		    <groupId>javax.xml.bind</groupId>
+		    <artifactId>jaxb-api</artifactId>
+		    <version>2.3.0</version>
+	    </dependency>
+    </dependencies>
 </project>


### PR DESCRIPTION
Since JDK9, JAXB is deprecated and was entirely removed in JDK11.
This change adds version 2.3.0 (used in JDK9) as an explicit dependency to instruct maven to include it in the generated archive.